### PR TITLE
Fix domain validity check

### DIFF
--- a/src/Domains/Domain.php
+++ b/src/Domains/Domain.php
@@ -60,7 +60,7 @@ class Domain
      */
     public function __construct(string $domain)
     {
-        if ((strpos($domain, 'http') === 0) || (strpos($domain, 'https') === 0)) {
+        if ((strpos($domain, 'http:') === 0) || (strpos($domain, 'https:') === 0)) {
             throw new Exception('$domain must be a valid domain or hostname');
         }
 


### PR DESCRIPTION
Domain validation check will fail if a domain starts with "http" or "https". Ex : httpmydomain.com.

Changing "http" and "https" to "http:" and "https:"