### PR TITLE
Safe import

### DIFF
--- a/data/import.php
+++ b/data/import.php
@@ -74,4 +74,8 @@ foreach ($list as $key => $line) {
     $comments = [];
 }
 
+if (!isset($domains['com'])) {
+    throw new RuntimeException(".com is missing from public suffix list; it must be corrupted");
+}
+
 file_put_contents(__DIR__.'/data.php', "<?php\n\nreturn ".arrayToCode($domains).';');

--- a/data/import.php
+++ b/data/import.php
@@ -9,20 +9,20 @@ $list = explode("\n", $data);
 
 function arrayToCode(array $data, $level = 0):string {
     $output = '['."\n";
-    
+
     $level++;
-    
-    $tabs = str_repeat ("\t", $level);
-    
+
+    $tabs = str_repeat("\t", $level);
+
     foreach($data as $key => $node) {
-        $key = is_integer($key) ? '' : '\''.$key.'\' => ';
-        $value = (is_array($node)) ? arrayToCode($node, $level) : str_replace("'", "\'", $node);
-        $output .= $tabs.$key.((is_string($node)) ? '\''.$value.'\'' : $value).(($key !== array_key_last($data)) ? ', ' : '')."\n";
+        $key = is_integer($key) ? '' : var_export($key, true) . ' => ';
+        $value = is_array($node) ? arrayToCode($node, $level) : var_export($node, true);
+        $output .= $tabs.$key.$value.",\n";
     }
 
     $level--;
 
-    $tabs = str_repeat ("\t", $level);
+    $tabs = str_repeat("\t", $level);
 
     $output .= $tabs.']';
 
@@ -39,18 +39,18 @@ foreach ($list as $key => $line) {
         $comments = [];
         continue;
     }
-    
+
     if(mb_strpos($line, '===END ICANN DOMAINS===')) {
         $type = null;
         continue;
     }
-    
+
     if(mb_strpos($line, '===BEGIN PRIVATE DOMAINS===')) {
         $type = 'PRIVATE';
         $comments = [];
         continue;
     }
-    
+
     if(mb_strpos($line, '===END PRIVATE DOMAINS===')) {
         $type = null;
         continue;

--- a/data/import.php
+++ b/data/import.php
@@ -1,6 +1,11 @@
 <?php
 
-$list = explode("\n", file_get_contents('https://publicsuffix.org/list/public_suffix_list.dat'));
+$data = file_get_contents('https://publicsuffix.org/list/public_suffix_list.dat');
+if ($data === false) {
+    throw new RuntimeException("Could not download public suffix list");
+}
+
+$list = explode("\n", $data);
 
 function arrayToCode(array $data, $level = 0):string {
     $output = '['."\n";


### PR DESCRIPTION
This PR:

* Makes `import.php` exit with an error code if the download fails, so that it can be used in automated scripts.
* Safely escapes the array keys when generating `data.php`.
* Refreshes `data.php` with the latest data from publicsuffix.org.

The original `import.php` doesn't safely escape the `$key` value, thereby trusting publicsuffix.org not to include single quotes in this field. It would potentially allow anyone controlling this domain name to execute arbitrary PHP code when `data.php` is loaded.