### PR TITLE
Fix: Failing jobs

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Commit and push
         run: |
           if git diff --exit-code data/data.php; then
-            exit 1
+            echo "Aborting action, remote data has not changed."
+            exit 0
           fi
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -1,6 +1,7 @@
 on:
   schedule:
     - cron: "12 3 * * *"
+  workflow_dispatch:
 
 jobs:
   import:


### PR DESCRIPTION
Currently, we return exit code 1 when the existing dataset is up to date. That is a problem for GitHub since it considers such a test failed and shoots notifications at us.

This PR makes sure the job exits successfully even when our data is up to date.

Tested the edge case on a fork:
<img width="1313" alt="CleanShot 2022-08-29 at 09 58 25@2x" src="https://user-images.githubusercontent.com/19310830/187153051-668c1499-d5c6-4538-87f6-1ae21e06a3eb.png">

