### PR TITLE
Add missing domains for nepal

### DIFF
--- a/data/data.php
+++ b/data/data.php
@@ -30346,11 +30346,65 @@ return [
 		'comments' => [
 		],
 	],
-	'*.np' => [
-		'suffix' => '*.np',
+	'np' => [
+		'suffix' => 'np',
 		'type' => 'ICANN',
 		'comments' => [
 			'np : http://www.mos.com.np/register.html',
+		],
+	],
+	'com.np' => [
+		'suffix' => 'com.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'edu.np' => [
+		'suffix' => 'edu.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'gov.np' => [
+		'suffix' => 'gov.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'net.np' => [
+		'suffix' => 'net.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'org.np' => [
+		'suffix' => 'org.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'info.np' => [
+		'suffix' => 'info.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'mil.np' => [
+		'suffix' => 'mil.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'name.np' => [
+		'suffix' => 'name.np',
+		'type' => 'ICANN',
+		'comments' => [
+		],
+	],
+	'coop.np' => [
+		'suffix' => 'coop.np',
+		'type' => 'ICANN',
+		'comments' => [
 		],
 	],
 	'nr' => [


### PR DESCRIPTION
Fixes https://github.com/appwrite/appwrite/issues/5317
data.php did not include data about .np domains.
The domains on official registration page on https://register.com.np/np-ccTLDs are added. Replacing *.np with np since none of the other ccTLD have them.