### PR TITLE
Allow certain domains to pass public domain validation check

### DIFF
--- a/src/Domains/Validator/PublicDomain.php
+++ b/src/Domains/Validator/PublicDomain.php
@@ -81,6 +81,6 @@ class PublicDomain extends Validator
      */
     public static function allow(array $domains): void
     {
-        self::$allowedDomains = array_merge(self::$allowedDomains, $domains);
+        self::$allowedDomains[] = $domains;
     }
 }

--- a/src/Domains/Validator/PublicDomain.php
+++ b/src/Domains/Validator/PublicDomain.php
@@ -81,6 +81,6 @@ class PublicDomain extends Validator
      */
     public static function allow(array $domains): void
     {
-        self::$allowedDomains[] = $domains;
+        self::$allowedDomains = array_merge(self::$allowedDomains, $domains);
     }
 }

--- a/src/Domains/Validator/PublicDomain.php
+++ b/src/Domains/Validator/PublicDomain.php
@@ -13,6 +13,10 @@ use Utopia\Validator;
 class PublicDomain extends Validator
 {
     /**
+     * @var array
+     */
+    protected static $allowedDomains = [];
+    /**
      * Get Description
      *
      * Returns validator description
@@ -27,7 +31,7 @@ class PublicDomain extends Validator
     /**
      * Is valid
      *
-     * Validation will pass when $value is a public domain
+     * Validation will pass when $value is either a known domain or in the list of allowed domains
      *
      * @param  mixed $value
      * @return bool
@@ -40,11 +44,8 @@ class PublicDomain extends Validator
         }
 
         $domain = new Domain($value);
-        if (!$domain->isKnown()) {
-            return false;
-        }
 
-        return true;
+        return $domain->isKnown() || in_array($domain->get(), self::$allowedDomains);
     }
 
     /**
@@ -69,5 +70,17 @@ class PublicDomain extends Validator
     public function getType(): string
     {
         return self::TYPE_STRING;
+    }
+
+    /**
+     * Allow domains
+     *
+     * Add domains to the allowed domains array
+     *
+     * @param array $domains
+     */
+    public static function allow(array $domains): void
+    {
+        self::$allowedDomains = array_merge(self::$allowedDomains, $domains);
     }
 }

--- a/tests/Validator/PublicDomainTest.php
+++ b/tests/Validator/PublicDomainTest.php
@@ -21,15 +21,20 @@ class PublicDomainTest extends TestCase
     public function testIsValid(): void
     {
         $this->assertEquals('Value must be a public domain', $this->domain->getDescription());
+        // Known public domains
         $this->assertEquals(true, $this->domain->isValid('example.com'));
         $this->assertEquals(true, $this->domain->isValid('google.com'));
         $this->assertEquals(true, $this->domain->isValid('bbc.co.uk'));
         $this->assertEquals(true, $this->domain->isValid('appwrite.io'));
         $this->assertEquals(true, $this->domain->isValid('usa.gov'));
         $this->assertEquals(true, $this->domain->isValid('stanford.edu'));
+
+        // URLs
         $this->assertEquals(true, $this->domain->isValid('http://google.com'));
         $this->assertEquals(true, $this->domain->isValid('http://www.google.com'));
         $this->assertEquals(true, $this->domain->isValid('https://example.com'));
+
+        // Private domains
         $this->assertEquals(false, $this->domain->isValid('localhost'));
         $this->assertEquals(false, $this->domain->isValid('http://localhost'));
         $this->assertEquals(false, $this->domain->isValid('sub.demo.localhost'));
@@ -38,5 +43,23 @@ class PublicDomainTest extends TestCase
         $this->assertEquals(false, $this->domain->isValid('qa.testing.internal'));
         $this->assertEquals(false, $this->domain->isValid('wiki.team.local'));
         $this->assertEquals(false, $this->domain->isValid('example.test'));
+    }
+
+    public function testAllowDomains(): void
+    {
+        // Adding localhost to allowed domains
+        PublicDomain::allow(['localhost']);
+
+        // Now localhost should be valid
+        $this->assertEquals(true, $this->domain->isValid('localhost'));
+        $this->assertEquals(true, $this->domain->isValid('http://localhost'));
+        $this->assertEquals(false, $this->domain->isValid('test.app.internal'));
+
+        // Adding more domains to allowed domains
+        PublicDomain::allow(['test.app.internal', 'home.local']);
+
+        // Now these domains should be valid
+        $this->assertEquals(true, $this->domain->isValid('test.app.internal'));
+        $this->assertEquals(true, $this->domain->isValid('home.local'));
     }
 }


### PR DESCRIPTION
This change allows the user to skip public domain checks while running tests locally.