### PR TITLE
Disallow spaces and shell characters in domains

### DIFF
--- a/src/Domains/Domain.php
+++ b/src/Domains/Domain.php
@@ -69,6 +69,17 @@ class Domain
             throw new Exception("'{$domain}' must be a valid domain or hostname");
         }
 
+        if (strpos($domain, ' ') !== false || strpos($domain, ';') !== false || strpos($domain, '|') !== false || strpos($domain, '&') !== false || strpos($domain, '>') !== false || strpos($domain, '<') !== false) {
+            throw new Exception("Spaces and shell metacharacters not allowed in {$domain} domain");
+        }
+
+        $labels = explode('.', $domain);
+        foreach ($labels as $label) {
+            if (strpos($label, '-') === 0 || strpos($label, '-') === strlen($label) - 1) {
+                throw new Exception("Hyphens not allowed at label edges in domain {$domain}");
+            }
+        }
+
         $this->domain = \mb_strtolower($domain);
         $this->parts = \explode('.', $this->domain);
 

--- a/tests/DomainTest.php
+++ b/tests/DomainTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Utopia PHP Framework
  *
@@ -210,6 +211,27 @@ class DomainTest extends TestCase
         $this->expectException(Exception::class);
 
         new Domain('https://facbook.com');
+    }
+
+    public function testDomainWithSpaces(): void
+    {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage("Spaces and shell metacharacters not allowed in rm -f -r * domain");
+        $domain = new Domain('rm -f -r *');
+    }
+
+    public function testDomainWithShellMetaCharacters(): void
+    {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage("Spaces and shell metacharacters not allowed in ls; cat /etc/passwd domain");
+        $domain = new Domain('ls; cat /etc/passwd');
+    }
+
+    public function testDomainWithHypens(): void
+    {
+        $this->expectException('Exception');
+        $this->expectExceptionMessage("Hyphens not allowed at label edges in domain -my--domain.com");
+        $domain = new Domain('-my--domain.com');
     }
 
     public function testExampleExampleCk(): void


### PR DESCRIPTION
Don't allow user injections in domains.