### PR TITLE
feat: add InvalidPeriodException for NameCom adapter

### DIFF
--- a/src/Domains/Registrar/Adapter/NameCom.php
+++ b/src/Domains/Registrar/Adapter/NameCom.php
@@ -10,6 +10,7 @@ use Utopia\Domains\Registrar\Exception\DomainTakenException;
 use Utopia\Domains\Registrar\Exception\InvalidAuthCodeException;
 use Utopia\Domains\Registrar\Exception\InvalidContactException;
 use Utopia\Domains\Registrar\Exception\AuthException;
+use Utopia\Domains\Registrar\Exception\InvalidPeriodException;
 use Utopia\Domains\Registrar\Exception\PriceNotFoundException;
 use Utopia\Domains\Registrar\Exception\DomainNotFoundException;
 use Utopia\Domains\Registrar\Exception\RateLimitException;
@@ -34,6 +35,7 @@ class NameCom extends Adapter
     public const ERROR_INVALID_CONTACT = 'invalid value for';
     public const ERROR_INVALID_DOMAIN = 'Invalid Domain Name';
     public const ERROR_INVALID_DOMAINS = 'None of the submitted domains are valid';
+    public const ERROR_INVALID_YEARS = 'Invalid value for years';
     public const ERROR_UNSUPPORTED_TLD = 'unsupported tld';
     public const ERROR_TLD_NOT_SUPPORTED = 'TLD not supported';
     public const ERROR_UNSUPPORTED_TRANSFER = 'do not support transfers for';
@@ -47,6 +49,7 @@ class NameCom extends Adapter
         self::ERROR_NOT_FOUND => 404,
         self::ERROR_DOMAIN_TAKEN => null,
         self::ERROR_INVALID_AUTH_CODE => null,
+        self::ERROR_INVALID_YEARS => 400,
         self::ERROR_INVALID_CONTACT => null,
         self::ERROR_INVALID_DOMAIN => null,
         self::ERROR_INVALID_DOMAINS => null,
@@ -414,6 +417,9 @@ class NameCom extends Adapter
                 case self::ERROR_NOT_FOUND:
                 case self::ERROR_INVALID_DOMAIN:
                     throw new PriceNotFoundException($message, $code, $e);
+
+                case self::ERROR_INVALID_YEARS:
+                    throw new InvalidPeriodException($message, $code, $e);
 
                 default:
                     throw new DomainsException($message, $code, $e);

--- a/src/Domains/Registrar/Exception/InvalidPeriodException.php
+++ b/src/Domains/Registrar/Exception/InvalidPeriodException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Utopia\Domains\Registrar\Exception;
+
+use Utopia\Domains\Exception;
+
+class InvalidPeriodException extends Exception
+{
+}

--- a/tests/Registrar/NameComTest.php
+++ b/tests/Registrar/NameComTest.php
@@ -7,6 +7,7 @@ use Utopia\Cache\Adapter\None as NoneAdapter;
 use Utopia\Domains\Cache;
 use Utopia\Domains\Registrar;
 use Utopia\Domains\Registrar\Exception\AuthException;
+use Utopia\Domains\Registrar\Exception\InvalidPeriodException;
 use Utopia\Domains\Registrar\Exception\UnsupportedTldException;
 use Utopia\Domains\Registrar\Adapter\NameCom;
 use Utopia\Domains\Registrar\UpdateDetails;
@@ -177,5 +178,15 @@ class NameComTest extends Base
     public function testCheckTransferStatus(): void
     {
         $this->markTestSkipped('Name.com for some reason always returning 404 (Not Found) for transfer status check. Investigate later.');
+    }
+
+    public function testGetPriceWithInvalidPeriod(): void
+    {
+        $domain = $this->generateRandomString() . '.ai';
+
+        $this->expectException(InvalidPeriodException::class);
+        $this->expectExceptionMessage('Failed to get price for domain: ' . $domain . ' - Invalid value for years for this domain');
+
+        $this->registrar->getPrice($domain, 1);
     }
 }


### PR DESCRIPTION
## Summary
- Add `InvalidPeriodException` thrown when NameCom API returns "Invalid value for years" (HTTP 400)
- Order `ERROR_INVALID_YEARS` before `ERROR_INVALID_CONTACT` in `ERROR_MAP` so the more specific pattern matches first (both share the `'invalid value for'` substring)
- Add error code `400` to the map entry for precise matching

## Test plan
- [x] `testGetPriceWithInvalidPeriod` passes — confirms `InvalidPeriodException` is thrown for invalid year values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain registrar validation to properly detect and handle invalid registration periods with clear error responses, preventing failed transactions.

* **Tests**
  * Added test coverage to verify correct error handling and messaging when invalid domain registration periods are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->