### PR TITLE
chore: allow utopia-php/cache 2.0.* alongside 1.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require": {
       "php": ">=8.2",
       "utopia-php/validators": "0.*",
-      "utopia-php/cache": "1.0.*"
+      "utopia-php/cache": "1.0.* || 2.0.*"
   },
   "require-dev": {
       "phpunit/phpunit": "^9.3",


### PR DESCRIPTION
## What

Widen the `utopia-php/cache` constraint from `1.0.*` to `1.0.* || 2.0.*`.

## Why

`utopia-php/cache` 2.0.0 was released ([release notes](https://github.com/utopia-php/cache/releases/tag/2.0.0)). It bumps the PHP floor to `>=8.2` (matches this package), adds a `CircuitBreaker` adapter and a `Feature\Telemetry` propagation contract — all additive. The `Utopia\Cache\Cache` type used in `src/Domains/Cache.php` is unchanged.

Allowing both 1.0.x and 2.0.x lets downstream consumers (e.g. appwrite/appwrite) pick up cache 2.0 without forcing existing users off 1.0.x.

## Test plan

- [ ] CI passes against both cache 1.0.x and 2.0.x