### PR TITLE
Fix premium domain pricing for aftermarket listings

### DIFF
--- a/src/Domains/Registrar.php
+++ b/src/Domains/Registrar.php
@@ -81,11 +81,12 @@ class Registrar
      * @param array|Contact $contacts
      * @param array $nameservers
      * @param bool $autorenewEnabled
+     * @param float|null $purchasePrice Required if domain is premium
      * @return string Order ID
      */
-    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false): string
+    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false, ?float $purchasePrice = null): string
     {
-        return $this->adapter->purchase($domain, $contacts, $periodYears, $nameservers, $autorenewEnabled);
+        return $this->adapter->purchase($domain, $contacts, $periodYears, $nameservers, $autorenewEnabled, $purchasePrice);
     }
 
     /**

--- a/src/Domains/Registrar/Adapter.php
+++ b/src/Domains/Registrar/Adapter.php
@@ -95,9 +95,10 @@ abstract class Adapter extends DomainsAdapter
      * @param  int  $periodYears
      * @param  array  $nameservers
      * @param  bool  $autorenewEnabled
+     * @param  float|null  $purchasePrice Required if domain is premium
      * @return string Order ID
      */
-    abstract public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false): string;
+    abstract public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false, ?float $purchasePrice = null): string;
 
     /**
      * Suggest domain names

--- a/src/Domains/Registrar/Adapter/Mock.php
+++ b/src/Domains/Registrar/Adapter/Mock.php
@@ -130,11 +130,12 @@ class Mock extends Adapter
      * @param int $periodYears
      * @param array $nameservers
      * @param bool $autorenewEnabled
+     * @param float|null $purchasePrice Required if domain is premium
      * @return string Order ID
      * @throws DomainTakenException
      * @throws InvalidContactException
      */
-    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false): string
+    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false, ?float $purchasePrice = null): string
     {
         if (!$this->available($domain)) {
             throw new DomainTakenException("Domain {$domain} is not available for registration", self::RESPONSE_CODE_DOMAIN_TAKEN);

--- a/src/Domains/Registrar/Adapter/NameCom.php
+++ b/src/Domains/Registrar/Adapter/NameCom.php
@@ -404,10 +404,22 @@ class NameCom extends Adapter
             // getPricing only covers standard registry registrations. Premium
             // aftermarket listings are priced by the availability endpoint, so
             // without this merge a premium domain is quoted at the base TLD price.
-            $availabilityResult = $this->send('POST', '/core/v1/domains:checkAvailability', [
-                'domainNames' => [$domain],
-            ]);
-            $availability = $availabilityResult['results'][0] ?? null;
+            $availability = null;
+            $availabilityFailed = false;
+            try {
+                $availabilityResult = $this->send('POST', '/core/v1/domains:checkAvailability', [
+                    'domainNames' => [$domain],
+                ]);
+                $availability = $availabilityResult['results'][0] ?? null;
+            } catch (RateLimitException $e) {
+                throw $e;
+            } catch (Exception $e) {
+                // Registry pricing is still usable for standard domains; skip
+                // the premium override and skip caching so the merge is
+                // retried on the next request
+                $availabilityFailed = true;
+            }
+
             $purchaseType = $availability['purchaseType'] ?? 'registration';
             if (
                 !empty($availability['purchasable'])
@@ -417,6 +429,8 @@ class NameCom extends Adapter
                 if (isset($availability['purchasePrice'])) {
                     $priceMap[Registrar::REG_TYPE_NEW] = (float) $availability['purchasePrice'];
                 }
+                // A renewal price of 0 means name.com has no renewal data for
+                // the listing, so keep the registry renewal price in that case
                 if (!empty($availability['renewalPrice'])) {
                     $priceMap[Registrar::REG_TYPE_RENEWAL] = (float) $availability['renewalPrice'];
                 }
@@ -426,7 +440,7 @@ class NameCom extends Adapter
                 throw new PriceNotFoundException("Price not found for domain: {$domain}", 400);
             }
 
-            if ($this->cache) {
+            if ($this->cache && !$availabilityFailed) {
                 $cacheData = array_map(
                     fn ($price) => ['price' => $price !== null ? (float) $price : null, 'premium' => $isPremium],
                     $priceMap

--- a/src/Domains/Registrar/Adapter/NameCom.php
+++ b/src/Domains/Registrar/Adapter/NameCom.php
@@ -170,9 +170,10 @@ class NameCom extends Adapter
      * @param int $periodYears Registration period in years
      * @param array $nameservers Nameservers to use
      * @param bool $autorenewEnabled Whether autorenew should be enabled
+     * @param float|null $purchasePrice Required if domain is premium
      * @return string Order ID
      */
-    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false): string
+    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false, ?float $purchasePrice = null): string
     {
         try {
             $contacts = \is_array($contacts) ? $contacts : [$contacts];
@@ -189,6 +190,10 @@ class NameCom extends Adapter
                 ],
                 'years' => $periodYears,
             ];
+
+            if ($purchasePrice !== null) {
+                $data['purchasePrice'] = $purchasePrice;
+            }
 
             $result = $this->send('POST', '/core/v1/domains', $data);
             return (string) ($result['order'] ?? '');
@@ -320,7 +325,13 @@ class NameCom extends Adapter
 
                 $purchasable = $domainResult['purchasable'] ?? false;
                 $price = isset($domainResult['purchasePrice']) ? (float) $domainResult['purchasePrice'] : null;
-                $isPremium = isset($domainResult['premium']) && $domainResult['premium'] === true;
+                $renewalPrice = isset($domainResult['renewalPrice']) ? (float) $domainResult['renewalPrice'] : null;
+                $purchaseType = $domainResult['purchaseType'] ?? 'registration';
+
+                // Aftermarket listings (purchaseType other than 'registration')
+                // are premium even when the premium flag is not set
+                $isPremium = (isset($domainResult['premium']) && $domainResult['premium'] === true)
+                    || ($purchaseType !== '' && $purchaseType !== 'registration');
 
                 // Apply price filters
                 if ($price !== null) {
@@ -343,6 +354,8 @@ class NameCom extends Adapter
                 $items[$domain] = [
                     'available' => $purchasable,
                     'price' => $price,
+                    'renewalPrice' => $renewalPrice,
+                    'purchaseType' => $purchaseType,
                     'type' => $isPremium ? 'premium' : 'suggestion',
                 ];
 
@@ -371,6 +384,9 @@ class NameCom extends Adapter
         if ($this->cache) {
             $cached = $this->cache->load($cacheKey, $ttl);
             if (\is_array($cached[$regType] ?? null)) {
+                if (($cached[$regType]['price'] ?? null) === null) {
+                    throw new PriceNotFoundException("Price not found for domain: {$domain}", 400);
+                }
                 return new Price($cached[$regType]['price'], $cached[$regType]['premium']);
             }
         }
@@ -385,13 +401,34 @@ class NameCom extends Adapter
                 Registrar::REG_TYPE_TRANSFER  => $result['transferPrice'] ?? null,
             ];
 
+            // getPricing only covers standard registry registrations. Premium
+            // aftermarket listings are priced by the availability endpoint, so
+            // without this merge a premium domain is quoted at the base TLD price.
+            $availabilityResult = $this->send('POST', '/core/v1/domains:checkAvailability', [
+                'domainNames' => [$domain],
+            ]);
+            $availability = $availabilityResult['results'][0] ?? null;
+            $purchaseType = $availability['purchaseType'] ?? 'registration';
+            if (
+                !empty($availability['purchasable'])
+                && (($availability['premium'] ?? false) === true || ($purchaseType !== '' && $purchaseType !== 'registration'))
+            ) {
+                $isPremium = true;
+                if (isset($availability['purchasePrice'])) {
+                    $priceMap[Registrar::REG_TYPE_NEW] = (float) $availability['purchasePrice'];
+                }
+                if (!empty($availability['renewalPrice'])) {
+                    $priceMap[Registrar::REG_TYPE_RENEWAL] = (float) $availability['renewalPrice'];
+                }
+            }
+
             if (!array_filter($priceMap, fn ($p) => $p !== null)) {
                 throw new PriceNotFoundException("Price not found for domain: {$domain}", 400);
             }
 
             if ($this->cache) {
                 $cacheData = array_map(
-                    fn ($price) => ['price' => (float) ($price ?? 0), 'premium' => $isPremium],
+                    fn ($price) => ['price' => $price !== null ? (float) $price : null, 'premium' => $isPremium],
                     $priceMap
                 );
                 $this->cache->save($cacheKey, $cacheData);

--- a/src/Domains/Registrar/Adapter/OpenSRS.php
+++ b/src/Domains/Registrar/Adapter/OpenSRS.php
@@ -177,7 +177,7 @@ class OpenSRS extends Adapter
         return $result;
     }
 
-    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false): string
+    public function purchase(string $domain, array|Contact $contacts, int $periodYears = 1, array $nameservers = [], bool $autorenewEnabled = false, ?float $purchasePrice = null): string
     {
         try {
             $contacts = \is_array($contacts) ? $contacts : [$contacts];
@@ -191,7 +191,7 @@ class OpenSRS extends Adapter
 
             $regType = Registrar::REG_TYPE_NEW;
 
-            $result = $this->register($domain, $regType, $this->user, $contacts, $nameservers, $periodYears, null, null, $autorenewEnabled);
+            $result = $this->register($domain, $regType, $this->user, $contacts, $nameservers, $periodYears, null, $purchasePrice, $autorenewEnabled);
             $result = $this->response($result);
             return $result['id'];
 


### PR DESCRIPTION
## What does this PR do?

Fixes premium (aftermarket) domains being quoted at the base TLD price. Name.com's `:getPricing` endpoint only covers standard registry registrations, so a premium listing like `appwrite.xyz` (~$2,242 one-time acquisition fee) was priced at the base .xyz promo price of $1.99.

### Changes

- **`NameCom::getPrice()`** now also consults `:checkAvailability`. When the domain is a purchasable premium listing (`premium` flag set, or a non-`registration` `purchaseType` such as `aftermarket`), its `purchasePrice`/`renewalPrice` override the registry pricing and the result is marked premium.
- **`NameCom::suggest()`** treats non-`registration` purchase types as premium and now exposes `renewalPrice` and `purchaseType` per suggestion.
- **`purchase()`** accepts an optional `purchasePrice` param (backward-compatible), which registrars require for premium registrations — mirroring the existing `transfer()` support. Wired through `Registrar`, `Adapter`, `NameCom` (request payload), `OpenSRS` (existing `register()` param) and `Mock`.
- **Cache fix:** `getPrice()` no longer caches `null` renewal/transfer prices as `0.0`; a cached `null` now raises `PriceNotFoundException` as the live path does.

### Test plan

- `composer lint`, `composer check` (PHPStan level 4) pass
- Mock suite and NameCom integration tests (availability/suggest/price) pass against `api.dev.name.com`
- Live check on dev: registry premium `nb.xyz` → $3,807.69 `premium: true`; standard domains unchanged. The aftermarket merge path can't be reproduced in name.com's dev sandbox (no aftermarket listings there); verified the data shape against production search results for `appwrite.xyz` (`premium: true`, ~$2,242) via the cloud suggestions endpoint.

### Related

- Consumer-side change in the cloud repo (passing `purchasePrice` at purchase confirmation and re-validating the quoted price) depends on this being released and bumped.